### PR TITLE
feat: 다이어리 작성 및 업데이트, 조회 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     implementation("androidx.room:room-guava:$room_version")
     testImplementation("androidx.room:room-testing:$room_version")
     implementation("androidx.room:room-paging:$room_version")
+    kapt ("androidx.room:room-compiler:$room_version")
 
     // Retrofit
     implementation(libs.retrofit)

--- a/app/src/main/java/net/ifmain/monologue/app/MainActivity.kt
+++ b/app/src/main/java/net/ifmain/monologue/app/MainActivity.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import net.ifmain.monologue.data.model.DiaryUiState
 import net.ifmain.monologue.ui.screen.DiaryHomeScreen
+import net.ifmain.monologue.ui.screen.DiaryListScreen
 import net.ifmain.monologue.ui.screen.IntroScreen
 import net.ifmain.monologue.ui.screen.auth.SignInScreen
 import net.ifmain.monologue.ui.screen.auth.SignUpScreen
@@ -91,6 +92,7 @@ fun StartNavigation(
         composable("diary_home_screen") {
             val diaryViewModel: DiaryViewModel = hiltViewModel()
             diaryViewModel.userId = userId ?: ""
+            diaryViewModel.syncOfflineEntries()
             DiaryHomeScreen(
                 viewModel = diaryViewModel,
                 onTextChange = diaryViewModel::onTextChange,
@@ -109,5 +111,18 @@ fun StartNavigation(
                 onNavigateToDiaryList = { navController.navigate("diary_list_screen") }
             )
         }
+
+        composable("diary_list_screen") {
+            val diaryViewModel: DiaryViewModel = hiltViewModel()
+            diaryViewModel.userId = userId ?: ""
+
+            DiaryListScreen(
+                viewModel = diaryViewModel,
+                onEntryClick = { entry ->
+//                    navController.navigate("diary_detail_screen/${entry.date}")
+                }
+            )
+        }
+
     }
 }

--- a/app/src/main/java/net/ifmain/monologue/data/api/DiaryApi.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/api/DiaryApi.kt
@@ -8,6 +8,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Query
 
 interface DiaryApi {
@@ -19,6 +20,9 @@ interface DiaryApi {
 
     @POST("/api/diary")
     suspend fun postDiary(@Body entry: DiaryEntryDto): Response<Unit>
+
+    @PUT("/api/diary")
+    suspend fun updateDiary(@Body entry: DiaryEntryDto): Response<Unit>
 
     @GET("/api/diary")
     suspend fun getDiaries(@Query("user_id") userId: String): List<DiaryEntryDto>

--- a/app/src/main/java/net/ifmain/monologue/data/dao/DiaryDao.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/dao/DiaryDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 import net.ifmain.monologue.data.model.DiaryEntry
 
@@ -11,6 +12,9 @@ import net.ifmain.monologue.data.model.DiaryEntry
 interface DiaryDao {
     @Insert(onConflict = OnConflictStrategy.Companion.REPLACE)
     suspend fun insert(entry: DiaryEntry)
+
+    @Update
+    suspend fun update(entry: DiaryEntry)
 
     @Query("SELECT * FROM diary_entries ORDER BY date DESC")
     fun getAll(): Flow<List<DiaryEntry>>
@@ -20,4 +24,10 @@ interface DiaryDao {
 
     @Query("SELECT * FROM diary_entries WHERE isSynced = 0")
     fun getUnsynced(): List<DiaryEntry>
+
+    @androidx.room.Transaction
+    suspend fun insertAndMarkSynced(entry: DiaryEntry) {
+        insert(entry)
+        markAsSynced(entry.date)
+    }
 }

--- a/app/src/main/java/net/ifmain/monologue/data/dao/DiaryDao.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/dao/DiaryDao.kt
@@ -14,4 +14,10 @@ interface DiaryDao {
 
     @Query("SELECT * FROM diary_entries ORDER BY date DESC")
     fun getAll(): Flow<List<DiaryEntry>>
+
+    @Query("UPDATE diary_entries SET isSynced = 1 WHERE date = :date")
+    suspend fun markAsSynced(date: String)
+
+    @Query("SELECT * FROM diary_entries WHERE isSynced = 0")
+    fun getUnsynced(): List<DiaryEntry>
 }

--- a/app/src/main/java/net/ifmain/monologue/data/dao/DiaryDatabase.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/dao/DiaryDatabase.kt
@@ -1,0 +1,10 @@
+package net.ifmain.monologue.data.dao
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import net.ifmain.monologue.data.model.DiaryEntry
+
+@Database(entities = [DiaryEntry::class], version = 1)
+abstract class DiaryDatabase : RoomDatabase() {
+    abstract fun diaryDao(): DiaryDao
+}

--- a/app/src/main/java/net/ifmain/monologue/data/di/AppModule.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/di/AppModule.kt
@@ -20,7 +20,7 @@ object AppModule {
     @Singleton
     fun provideRetrofit(): Retrofit {
         return Retrofit.Builder()
-            .baseUrl("http://192.168.45.196:8080/")
+            .baseUrl("http://192.168.45.28:8080/")
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/app/src/main/java/net/ifmain/monologue/data/di/AppModule.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/di/AppModule.kt
@@ -20,7 +20,7 @@ object AppModule {
     @Singleton
     fun provideRetrofit(): Retrofit {
         return Retrofit.Builder()
-            .baseUrl("http://192.168.45.28:8080/")
+            .baseUrl("http://192.168.45.33:8080/")
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/app/src/main/java/net/ifmain/monologue/data/di/DatabaseModule.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/di/DatabaseModule.kt
@@ -1,0 +1,32 @@
+package net.ifmain.monologue.data.di
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import net.ifmain.monologue.data.dao.DiaryDao
+import net.ifmain.monologue.data.dao.DiaryDatabase
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): DiaryDatabase {
+        return Room.databaseBuilder(
+            context,
+            DiaryDatabase::class.java,
+            "diary_db"
+        ).build()
+    }
+
+    @Provides
+    fun provideDiaryDao(database: DiaryDatabase): DiaryDao {
+        return database.diaryDao()
+    }
+}

--- a/app/src/main/java/net/ifmain/monologue/data/model/DiaryUiState.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/model/DiaryUiState.kt
@@ -2,5 +2,5 @@ package net.ifmain.monologue.data.model
 
 data class DiaryUiState(
     val text: String = "",
-    val selectedMood: String? = null
+    val selectedMood: String = ""
 )

--- a/app/src/main/java/net/ifmain/monologue/data/model/UserDto.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/model/UserDto.kt
@@ -1,6 +1,8 @@
 package net.ifmain.monologue.data.model
 
 data class UserDto(
+    val id: String,
+    val name: String,
     val email: String,
     val password: String,
 )

--- a/app/src/main/java/net/ifmain/monologue/data/preference/UserPreferenceKeys.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/preference/UserPreferenceKeys.kt
@@ -3,6 +3,8 @@ package net.ifmain.monologue.data.preference
 import androidx.datastore.preferences.core.stringPreferencesKey
 
 object UserPreferenceKeys {
+    val USER_ID = stringPreferencesKey("user_id")
+    val USER_NAME = stringPreferencesKey("user_name")
     val USER_EMAIL = stringPreferencesKey("user_email")
     val USER_PASSWORD = stringPreferencesKey("user_password")
 }

--- a/app/src/main/java/net/ifmain/monologue/data/preference/UserPreferenceManager.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/preference/UserPreferenceManager.kt
@@ -14,13 +14,22 @@ class UserPreferenceManager @Inject constructor(private val context: Context) {
 
     val userInfoFlow: Flow<Pair<String?, String?>> = dataStore.data
         .map { prefs ->
+            val userId = prefs[UserPreferenceKeys.USER_ID]
+            val name = prefs[UserPreferenceKeys.USER_NAME]
             val email = prefs[UserPreferenceKeys.USER_EMAIL]
             val password = prefs[UserPreferenceKeys.USER_PASSWORD]
             Pair(email, password)
         }
 
-    suspend fun saveUserInfo(email: String, password: String) {
+    suspend fun saveUserInfo(
+        userId: String,
+        name: String,
+        email: String,
+        password: String
+    ) {
         dataStore.edit { prefs ->
+            prefs[UserPreferenceKeys.USER_ID] = userId
+            prefs[UserPreferenceKeys.USER_NAME] = name
             prefs[UserPreferenceKeys.USER_EMAIL] = email
             prefs[UserPreferenceKeys.USER_PASSWORD] = password
         }

--- a/app/src/main/java/net/ifmain/monologue/data/repository/DiaryRepository.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/repository/DiaryRepository.kt
@@ -1,17 +1,20 @@
 package net.ifmain.monologue.data.repository
 
+import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import net.ifmain.monologue.data.api.DiaryApi
 import net.ifmain.monologue.data.dao.DiaryDao
 import net.ifmain.monologue.data.model.DiaryEntry
 import net.ifmain.monologue.data.model.DiaryEntryDto
+import java.time.LocalDate
 import javax.inject.Inject
 
 class DiaryRepository @Inject constructor(
     private val dao: DiaryDao,
-    private val api: DiaryApi
+    internal val api: DiaryApi
 ) {
     fun getEntries(): Flow<List<DiaryEntry>> = dao.getAll()
+    data class DiaryCheckResponse(val status: String)
 
     suspend fun saveEntry(entry: DiaryEntry, userId: String) {
         dao.insert(entry)
@@ -25,6 +28,36 @@ class DiaryRepository @Inject constructor(
             val response = api.postDiary(dto)
             if (response.isSuccessful) {
                 dao.markAsSynced(entry.date)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    suspend fun checkDiaryExists(userId: String): Boolean {
+        val todayDate = LocalDate.now().toString()
+        try {
+            val diaries = api.getDiaries(userId)
+            return diaries.any { it.date == todayDate }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return false
+        }
+    }
+
+    suspend fun updateEntry(entry: DiaryEntry, userId: String) {
+        try {
+            val dto = DiaryEntryDto(
+                date = entry.date,
+                text = entry.text,
+                mood = entry.mood,
+                userId = userId
+            )
+            val response = api.updateDiary(dto)
+            if (response.isSuccessful) {
+                Log.d("DiaryRepository", "Diary entry updated successfully.")
+            } else {
+                Log.e("DiaryRepository", "Failed to update diary: ${response.message()}")
             }
         } catch (e: Exception) {
             e.printStackTrace()

--- a/app/src/main/java/net/ifmain/monologue/data/repository/DiaryRepository.kt
+++ b/app/src/main/java/net/ifmain/monologue/data/repository/DiaryRepository.kt
@@ -1,7 +1,9 @@
 package net.ifmain.monologue.data.repository
 
 import android.util.Log
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 import net.ifmain.monologue.data.api.DiaryApi
 import net.ifmain.monologue.data.dao.DiaryDao
 import net.ifmain.monologue.data.model.DiaryEntry
@@ -14,7 +16,6 @@ class DiaryRepository @Inject constructor(
     internal val api: DiaryApi
 ) {
     fun getEntries(): Flow<List<DiaryEntry>> = dao.getAll()
-    data class DiaryCheckResponse(val status: String)
 
     suspend fun saveEntry(entry: DiaryEntry, userId: String) {
         dao.insert(entry)
@@ -28,24 +29,17 @@ class DiaryRepository @Inject constructor(
             val response = api.postDiary(dto)
             if (response.isSuccessful) {
                 dao.markAsSynced(entry.date)
+                Log.d("DiaryRepository", "Diary saved and marked as synced.")
+            } else {
+                Log.e("DiaryRepository", "Failed to save diary: ${response.message()}")
             }
         } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
-    suspend fun checkDiaryExists(userId: String): Boolean {
-        val todayDate = LocalDate.now().toString()
-        try {
-            val diaries = api.getDiaries(userId)
-            return diaries.any { it.date == todayDate }
-        } catch (e: Exception) {
-            e.printStackTrace()
-            return false
+            Log.e("DiaryRepository", "Error saving diary", e)
         }
     }
 
     suspend fun updateEntry(entry: DiaryEntry, userId: String) {
+        dao.insert(entry)
         try {
             val dto = DiaryEntryDto(
                 date = entry.date,
@@ -55,12 +49,49 @@ class DiaryRepository @Inject constructor(
             )
             val response = api.updateDiary(dto)
             if (response.isSuccessful) {
-                Log.d("DiaryRepository", "Diary entry updated successfully.")
+                dao.markAsSynced(entry.date)
+                Log.d("DiaryRepository", "Diary updated and marked as synced.")
             } else {
                 Log.e("DiaryRepository", "Failed to update diary: ${response.message()}")
             }
         } catch (e: Exception) {
+            Log.e("DiaryRepository", "Error updating diary", e)
+        }
+    }
+
+    suspend fun checkDiaryExists(userId: String): Boolean {
+        val todayDate = LocalDate.now().toString()
+        return try {
+            val diaries = api.getDiaries(userId)
+            diaries.any { it.date == todayDate }
+        } catch (e: Exception) {
             e.printStackTrace()
+            false
+        }
+    }
+
+    suspend fun syncUnsyncedEntries(userId: String) {
+        val unsyncedEntries = withContext(Dispatchers.IO) {
+            dao.getUnsynced()
+        }
+        for (entry in unsyncedEntries) {
+            try {
+                val dto = DiaryEntryDto(
+                    date = entry.date,
+                    text = entry.text,
+                    mood = entry.mood,
+                    userId = userId
+                )
+                val response = api.postDiary(dto)
+                if (response.isSuccessful) {
+                    dao.markAsSynced(entry.date)
+                    Log.d("DiaryRepository", "Synced diary for date=${entry.date}")
+                } else {
+                    Log.e("DiaryRepository", "Failed to sync diary: ${response.message()}")
+                }
+            } catch (e: Exception) {
+                Log.e("DiaryRepository", "Error syncing diary for date=${entry.date}", e)
+            }
         }
     }
 }

--- a/app/src/main/java/net/ifmain/monologue/ui/screen/DiaryHomeScreen.kt
+++ b/app/src/main/java/net/ifmain/monologue/ui/screen/DiaryHomeScreen.kt
@@ -160,6 +160,7 @@ fun DiaryHomeScreen(
                             },
                             onSuccess = {
                                 Toast.makeText(context, "저장되었습니다!", Toast.LENGTH_SHORT).show()
+                                onNavigateToDiaryList()
                             }
                         )
                     }
@@ -213,6 +214,7 @@ fun DiaryHomeScreen(
                                 viewModel.updateDiary(uiState, viewModel.userId)
                                 Toast.makeText(context, "수정되었습니다!", Toast.LENGTH_SHORT).show()
                                 showDialog = false
+                                onNavigateToDiaryList()
                             },
                             shape = RoundedCornerShape(12.dp),
                             modifier = Modifier.padding(8.dp),
@@ -235,7 +237,7 @@ fun DiaryHomeScreen(
                             shape = RoundedCornerShape(12.dp),
                             modifier = Modifier.padding(8.dp),
                             colors = ButtonDefaults.textButtonColors(
-                                contentColor = Color(0xFF9E9E9E), // 회색 버튼 색상
+                                contentColor = Color(0xFF9E9E9E),
                                 containerColor = Color.Transparent
                             )
                         ) {

--- a/app/src/main/java/net/ifmain/monologue/ui/screen/DiaryHomeScreen.kt
+++ b/app/src/main/java/net/ifmain/monologue/ui/screen/DiaryHomeScreen.kt
@@ -1,6 +1,7 @@
 package net.ifmain.monologue.ui.screen
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -24,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import net.ifmain.monologue.data.model.DiaryUiState
@@ -33,22 +33,29 @@ import net.ifmain.monologue.ui.theme.Cream
 import net.ifmain.monologue.ui.theme.Honey
 import net.ifmain.monologue.ui.theme.Lemon
 import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color.Companion.LightGray
 import androidx.compose.ui.platform.LocalContext
+import net.ifmain.monologue.viewmodel.DiaryViewModel
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun HomeScreen(
-    uiState: DiaryUiState,
+fun DiaryHomeScreen(
+    viewModel: DiaryViewModel,
     onTextChange: (String) -> Unit,
     onMoodSelect: (String) -> Unit,
     onAnalyzeClick: () -> Unit,
     onSaveClick: (String?, String) -> Unit,
     onNavigateToDiaryList: () -> Unit,
 ) {
+    val uiState = viewModel.uiState
     val context = LocalContext.current
     val moods = listOf("😊", "😐", "😢", "😡", "😴", "😍", "❓")
 
-    Scaffold (
+    Scaffold(
         containerColor = Cream,
         topBar = {
             TitleBar()
@@ -70,9 +77,17 @@ fun HomeScreen(
 
             OutlinedTextField(
                 value = uiState.text,
-                onValueChange = onTextChange,
+                onValueChange = {onTextChange(it)
+                                Log.d("DiaryHomeScreen", "Text changed: $it")
+                },
+
                 modifier = Modifier.fillMaxWidth(),
-                placeholder = { Text("오늘 하루를 한 줄로 남겨보세요") },
+                placeholder = {
+                    Text(
+                        text = "오늘 하루를 한 줄로 남겨보세요",
+                        style = TextStyle(color = LightGray)
+                    )
+                },
                 maxLines = 3,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = Lemon,
@@ -100,7 +115,10 @@ fun HomeScreen(
                                 else Color.Transparent
                             )
                             .padding(8.dp)
-                            .clickable { onMoodSelect(mood) }
+                            .clickable {
+                                Log.d("DiaryHomeScreen", "Mood clicked: $mood")
+                                onMoodSelect(mood)
+                            }
                     )
                 }
             }

--- a/app/src/main/java/net/ifmain/monologue/ui/screen/DiaryListScreen.kt
+++ b/app/src/main/java/net/ifmain/monologue/ui/screen/DiaryListScreen.kt
@@ -1,54 +1,109 @@
 package net.ifmain.monologue.ui.screen
 
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.ifmain.monologue.data.model.DiaryEntry
+import net.ifmain.monologue.ui.component.TitleBar
+import net.ifmain.monologue.ui.theme.Cream
+import net.ifmain.monologue.ui.theme.Lemon
+import net.ifmain.monologue.viewmodel.DiaryViewModel
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun DiaryListScreen(
-    entries: List<DiaryEntry>,
+    viewModel: DiaryViewModel,
     onEntryClick: (DiaryEntry) -> Unit
 ) {
-    LazyColumn(
+    val entries by viewModel.entries.collectAsStateWithLifecycle()
+
+    Scaffold(
+        containerColor = Cream,
+        topBar = {
+            TitleBar()
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(entries) { entry ->
+                DiaryCard(entry = entry, onEntryClick = onEntryClick)
+            }
+        }
+    }
+}
+
+@Composable
+fun DiaryCard(
+    entry: DiaryEntry,
+    onEntryClick: (DiaryEntry) -> Unit
+) {
+    Card(
         modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
+            .fillMaxWidth()
+            .clickable { onEntryClick(entry) },
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White
+        ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 6.dp
+        )
     ) {
-//        items(entries) { entry ->
-//            Card(
-//                modifier = Modifier
-//                    .fillMaxWidth()
-//                    .padding(vertical = 6.dp)
-//                    .clickable { onEntryClick(entry) },
-//                elevation = CardDefaults.cardElevation(4.dp)
-//            ) {
-//                Column(modifier = Modifier.padding(16.dp)) {
-//                    Row(
-//                        horizontalArrangement = Arrangement.SpaceBetween,
-//                        modifier = Modifier.fillMaxWidth()
-//                    ) {
-//                        Text(
-//                            text = entry.date,
-//                            style = MaterialTheme.typography.labelLarge
-//                        )
-//                        Text(
-//                            text = entry.mood ?: "❓",
-//                            fontSize = 20.sp
-//                        )
-//                    }
-//                    Spacer(Modifier.height(4.dp))
-//                    Text(
-//                        text = entry.text,
-//                        style = MaterialTheme.typography.bodyLarge,
-//                        maxLines = 2,
-//                        overflow = TextOverflow.Ellipsis
-//                    )
-//                }
-//            }
-//        }
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = formatDate(entry.date),
+                fontSize = 14.sp,
+                color = Lemon,
+                fontWeight = FontWeight.Bold
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = entry.text,
+                    fontSize = 16.sp,
+                    color = Color.DarkGray,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = entry.mood ?: "❓",
+                    fontSize = 24.sp,
+                    modifier = Modifier.padding(start = 8.dp),
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+private fun formatDate(date: String): String {
+    return try {
+        val parsedDate = LocalDate.parse(date)
+        parsedDate.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
+    } catch (e: Exception) {
+        date
     }
 }

--- a/app/src/main/java/net/ifmain/monologue/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/net/ifmain/monologue/ui/screen/HomeScreen.kt
@@ -1,6 +1,7 @@
 package net.ifmain.monologue.ui.screen
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -32,6 +33,7 @@ import net.ifmain.monologue.ui.theme.Cream
 import net.ifmain.monologue.ui.theme.Honey
 import net.ifmain.monologue.ui.theme.Lemon
 import androidx.compose.foundation.lazy.items
+import androidx.compose.ui.platform.LocalContext
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -40,9 +42,10 @@ fun HomeScreen(
     onTextChange: (String) -> Unit,
     onMoodSelect: (String) -> Unit,
     onAnalyzeClick: () -> Unit,
-    onSaveClick: () -> Unit,
+    onSaveClick: (String?, String) -> Unit,
     onNavigateToDiaryList: () -> Unit,
 ) {
+    val context = LocalContext.current
     val moods = listOf("😊", "😐", "😢", "😡", "😴", "😍", "❓")
 
     Scaffold (
@@ -115,8 +118,16 @@ fun HomeScreen(
 //            }
 
             Button(
-                onClick = onSaveClick,
-                enabled = uiState.text.isNotBlank(),
+                onClick = {
+                    if (uiState.selectedMood.isBlank()) {
+                        Toast.makeText(context, "감정을 선택해 주세요", Toast.LENGTH_SHORT).show()
+                    } else {
+                        val textToSave = if (uiState.text.isBlank()) "기록없음" else uiState.text
+                        onSaveClick(uiState.selectedMood, textToSave)
+                        Toast.makeText(context, "저장되었습니다!", Toast.LENGTH_SHORT).show()
+                    }
+                },
+                enabled = true,
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Lemon,
@@ -127,22 +138,4 @@ fun HomeScreen(
             }
         }
     }
-}
-
-@Preview
-@Composable
-fun HomeScreenPreview() {
-    val uiState = DiaryUiState(
-        text = "오늘은 정말 좋은 날이었어요!",
-        selectedMood = "😊"
-    )
-
-    HomeScreen(
-        uiState = uiState,
-        onTextChange = {},
-        onMoodSelect = {},
-        onAnalyzeClick = {},
-        onSaveClick = {},
-        onNavigateToDiaryList = { /* TODO */ }
-    )
 }

--- a/app/src/main/java/net/ifmain/monologue/ui/screen/IntroScreen.kt
+++ b/app/src/main/java/net/ifmain/monologue/ui/screen/IntroScreen.kt
@@ -50,7 +50,7 @@ import net.ifmain.monologue.viewmodel.IntroViewModel
 fun IntroScreen(
     onSignInClick: () -> Unit,
     onSignUpClick: () -> Unit,
-    onNavigateToMain: () -> Unit,
+    onNavigateToMain: (name: String, userId: String) -> Unit,
     viewModel: IntroViewModel = hiltViewModel()
 ) {
     var isLogoCentered by remember { mutableStateOf(true) }
@@ -62,13 +62,13 @@ fun IntroScreen(
     LaunchedEffect(Unit) {
         delay(2000)
         viewModel.checkAutoLogin(
-            onAutoLoginSuccess = { name ->
+            onAutoLoginSuccess = { name, userId ->
                 Toast.makeText(
                     context,
                     "${name}님 환영합니다!",
                     Toast.LENGTH_SHORT
                 ).show()
-                onNavigateToMain()
+                onNavigateToMain(name, userId)
             },
             onLoginFail = { isLogoCentered = false }
         )

--- a/app/src/main/java/net/ifmain/monologue/ui/screen/auth/SignInScreen.kt
+++ b/app/src/main/java/net/ifmain/monologue/ui/screen/auth/SignInScreen.kt
@@ -38,7 +38,7 @@ import net.ifmain.monologue.viewmodel.SignInViewModel
 @Composable
 fun SignInScreen(
     viewModel: SignInViewModel = hiltViewModel(),
-    onSignInClick: () -> Unit
+    onSignInClick: (name: String, userId: String) -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
     val context = LocalContext.current
@@ -89,7 +89,7 @@ fun SignInScreen(
                                                 "${name}님 환영합니다!",
                                                 Toast.LENGTH_SHORT
                                             ).show()
-                                            onSignInClick()
+                                            onSignInClick(name, viewModel.userId)
                                         },
                                         onError = { errorMsg ->
                                             Toast.makeText(context, errorMsg, Toast.LENGTH_SHORT)

--- a/app/src/main/java/net/ifmain/monologue/ui/screen/auth/SignUpScreen.kt
+++ b/app/src/main/java/net/ifmain/monologue/ui/screen/auth/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package net.ifmain.monologue.ui.screen.auth
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -36,7 +37,7 @@ import net.ifmain.monologue.viewmodel.SignUpViewModel
 @Composable
 fun SignUpScreen(
     viewModel: SignUpViewModel = hiltViewModel(),
-    onNavigateToMain: () -> Unit
+    onNavigateToMain: (name: String, userId: String) -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
     val context = LocalContext.current
@@ -93,7 +94,13 @@ fun SignUpScreen(
                                 else -> {
                                     viewModel.signUp(
                                         onSuccess = {
-                                            onNavigateToMain()
+                                            onNavigateToMain(
+                                                viewModel.username,
+                                                viewModel.userId
+                                            )
+
+                                            Log.d("SignUpViewModel", "Sending signup with: userId=${viewModel.userId}, username=${viewModel.username}, email=${viewModel.email}, password=${viewModel.password}")
+
                                             Toast.makeText(context, "회원가입 성공!", Toast.LENGTH_SHORT)
                                                 .show()
                                         },

--- a/app/src/main/java/net/ifmain/monologue/viewmodel/DiaryViewModel.kt
+++ b/app/src/main/java/net/ifmain/monologue/viewmodel/DiaryViewModel.kt
@@ -4,14 +4,22 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import net.ifmain.monologue.data.model.DiaryEntry
 import net.ifmain.monologue.data.model.DiaryUiState
+import net.ifmain.monologue.data.repository.DiaryRepository
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
-class DiaryViewModel @Inject constructor() : ViewModel() {
+class DiaryViewModel @Inject constructor(
+    private val repository: DiaryRepository
+) : ViewModel() {
     var uiState by mutableStateOf(DiaryUiState())
         private set
+    var userId by mutableStateOf<String>("")
 
     fun onTextChange(newText: String) {
         uiState = uiState.copy(text = newText)
@@ -21,11 +29,43 @@ class DiaryViewModel @Inject constructor() : ViewModel() {
         uiState = uiState.copy(selectedMood = mood)
     }
 
+    fun onSaveClick(onError: (String) -> Unit, onSuccess: () -> Unit) {
+        if (uiState.selectedMood.isBlank()) {
+            onError("감정을 선택해 주세요")
+            return
+        }
+
+        val finalText = if (uiState.text.isBlank()) "기록없음" else uiState.text
+
+        println("💾 저장됨: 텍스트=$finalText, 감정=${uiState.selectedMood}")
+
+        val currentUserId = userId
+        if (false) {
+            onError("유저 정보가 없습니다.")
+            return
+        }
+
+        onSuccess()
+        saveDiary(uiState, currentUserId)
+    }
+
+    fun saveDiary(uiState: DiaryUiState, userId: String) {
+        val today = LocalDate.now().toString()
+        val entry = DiaryEntry(
+            date = today,
+            text = if (uiState.text.isBlank()) "기록 없음" else uiState.text,
+            mood = uiState.selectedMood,
+            isSynced = false
+        )
+
+        viewModelScope.launch {
+            repository.saveEntry(entry, userId)
+        }
+    }
+
     fun onAnalyzeClick() {
         // 감정 분석 API 호출 후 상태 업데이트
     }
 
-    fun onSaveClick() {
-        // 로컬 저장 or 서버 API 호출
-    }
 }
+

--- a/app/src/main/java/net/ifmain/monologue/viewmodel/IntroViewModel.kt
+++ b/app/src/main/java/net/ifmain/monologue/viewmodel/IntroViewModel.kt
@@ -19,18 +19,20 @@ class IntroViewModel @Inject constructor(
 ) : ViewModel() {
     var isButtonVisible = mutableStateOf(false)
         private set
+    var userId by mutableStateOf("")
     var userName by mutableStateOf("")
 
-    fun checkAutoLogin(onAutoLoginSuccess: (String) -> Unit, onLoginFail: () -> Unit) {
+    fun checkAutoLogin(onAutoLoginSuccess: (String, String) -> Unit, onLoginFail: () -> Unit) {
         viewModelScope.launch {
             userPrefs.userInfoFlow.collect { (email, password) ->
                 if (!email.isNullOrBlank() && !password.isNullOrBlank()) {
                     try {
-                        val response = api.postSignIn(UserDto(email, password))
+                        val response = api.postSignIn(UserDto(userId, userName, email, password))
                         if (response.isSuccessful && response.body() != null) {
                             val body = response.body()
+                            userId = body?.id.toString()
                             userName = body?.name.toString()
-                            onAutoLoginSuccess(userName)
+                            onAutoLoginSuccess(userName, userId)
                         } else {
                             isButtonVisible.value = true
                             onLoginFail()

--- a/app/src/main/java/net/ifmain/monologue/viewmodel/SignInViewModel.kt
+++ b/app/src/main/java/net/ifmain/monologue/viewmodel/SignInViewModel.kt
@@ -18,15 +18,18 @@ class SignInViewModel @Inject constructor(
     private val userPrefs: UserPreferenceManager,
     private val api: DiaryApi,
 ) : ViewModel() {
+    var userId by mutableStateOf("")
+    var userName by mutableStateOf("")
     var email by mutableStateOf("")
     var password by mutableStateOf("")
-    var userName by mutableStateOf("")
 
     fun signIn(onSuccess: (String) -> Unit, onError: (String) -> Unit) {
         viewModelScope.launch {
             try {
                 val response = api.postSignIn(
                     UserDto(
+                        id = userId,
+                        name = userName,
                         email = email,
                         password = password
                     )
@@ -36,7 +39,7 @@ class SignInViewModel @Inject constructor(
                     val body = response.body()
                     if (body != null) {
                         userName = body.name.toString()
-                        userPrefs.saveUserInfo(email, password)
+                        userPrefs.saveUserInfo(userId, userName, email, password)
                         onSuccess(userName)
                     } else {
                         onError("응답이 비어있습니다.")

--- a/app/src/main/java/net/ifmain/monologue/viewmodel/SignUpViewModel.kt
+++ b/app/src/main/java/net/ifmain/monologue/viewmodel/SignUpViewModel.kt
@@ -18,6 +18,7 @@ class SignUpViewModel @Inject constructor(
     private val userPrefs: UserPreferenceManager,
     private val api: DiaryApi,
 ) : ViewModel() {
+    var userId by mutableStateOf("")
     var email by mutableStateOf("")
     var username by mutableStateOf("")
     var password by mutableStateOf("")
@@ -50,7 +51,7 @@ class SignUpViewModel @Inject constructor(
                 )
 
                 if (response.isSuccessful) {
-                    userPrefs.saveUserInfo(email, password)
+                    userPrefs.saveUserInfo(userId, username, email, password)
                     onSuccess()
                 } else {
                     onError("회원가입에 실패했습니다. (${response.code()})")


### PR DESCRIPTION
## 📌 작업 내용
- **다이어리 작성 UI 구현**
-사용자가 텍스트와 감정을 선택하여 다이어리 작성 가능하도록 UI 구현
-작성한 다이어리 데이터를 서버와 연동하여 저장 처리

- **다이어리 수정 및 업데이트 기능**
-사용자가 기존에 작성한 다이어리를 수정하고 서버에 업데이트 할 수 있는 기능 추가
-수정 시 기존 내용이 자동으로 불러와져 UI에 표시되도록 구현

- **다이어리 목록 조회 기능**
-사용자가 등록한 모든 다이어리를 리스트 형식으로 조회할 수 있는 화면 추가
-각 다이어리 항목 클릭 시 해당 다이어리의 세부 정보 보기 가능

- **자동 백그라운드 동기화 (unsynced entries)**
-네트워크 연결이 복구되면, 로컬에 저장된 unsynced된 다이어리 항목들을 자동으로 서버와 동기화 처리
-서버와의 통신 실패 시에도 로컬 데이터는 안전하게 유지되며, 성공적으로 동기화되면 서버에서 상태 업데이트

## ✅ 테스트 완료 여부
- [o] 다이어리 작성 시 텍스트와 감정을 입력하고 저장된 데이터를 서버에 정상적으로 전송하는지 확인
- [o] 다이어리 수정 시 기존 내용이 정상적으로 불러와지고 수정 후 저장이 잘 되는지 확인
- [o] 다이어리 목록 조회 시 이전에 작성한 다이어리들이 잘 출력되는지 확인
- [o] 네트워크 연결이 복구되었을 때 로컬의 unsynced된 다이어리가 자동으로 서버와 동기화되는지 확인

## 🔁 기타 사항
- 다이어리 삭제 기능 추가 필요