### PR TITLE
Release/1.0.1 rc1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "net.ifmain.monologue"
         minSdk = 26
         targetSdk = 35
-        versionCode = 3
-        versionName = "1.0"
+        versionCode = 4
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "BASE_URL", "\"$BASE_URL\"")
@@ -38,7 +38,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.extended)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -34,3 +34,77 @@
 # Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
 -keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
 -keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+
+# Keep line numbers for better crash reports
+-keepattributes SourceFile,LineNumberTable
+
+# Monologue app specific rules
+# Keep all data model classes
+-keep class net.ifmain.monologue.data.model.** { *; }
+
+# Keep API interface
+-keep interface net.ifmain.monologue.data.api.DiaryApi { *; }
+
+# Keep Room database classes
+-keep class net.ifmain.monologue.data.dao.DiaryDatabase { *; }
+-keep interface net.ifmain.monologue.data.dao.DiaryDao { *; }
+-keep class net.ifmain.monologue.data.dao.DiaryDatabase_Impl { *; }
+
+# Keep repository classes
+-keep class net.ifmain.monologue.data.repository.DiaryRepository { *; }
+
+# Retrofit
+-keepattributes Signature
+-keepattributes *Annotation*
+-keep class retrofit2.** { *; }
+-keepclasseswithmembers class * {
+    @retrofit2.http.* <methods>;
+}
+
+# OkHttp
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-keep class okhttp3.** { *; }
+-keep interface okhttp3.** { *; }
+
+# Hilt
+-keep class dagger.hilt.** { *; }
+-keep class javax.inject.** { *; }
+-keep class * extends dagger.hilt.android.lifecycle.HiltViewModel
+-keep @dagger.hilt.InstallIn class * { *; }
+-keep @dagger.hilt.android.lifecycle.HiltViewModel class * { *; }
+
+# Room
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-dontwarn androidx.room.paging.**
+
+# Compose
+-keep class androidx.compose.** { *; }
+-keep class kotlin.Unit
+
+# Firebase
+-keep class com.google.firebase.** { *; }
+-dontwarn com.google.firebase.**
+
+# Keep DataStore
+-keep class androidx.datastore.** { *; }
+
+# Coroutines
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+-keep class kotlinx.coroutines.android.AndroidExceptionPreHandler { *; }
+
+# Keep native methods
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# Remove logs in release
+-assumenosideeffects class android.util.Log {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** e(...);
+}

--- a/app/src/main/java/net/ifmain/monologue/ui/component/InputTextField.kt
+++ b/app/src/main/java/net/ifmain/monologue/ui/component/InputTextField.kt
@@ -1,11 +1,20 @@
 package net.ifmain.monologue.ui.component
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Color.Companion.DarkGray
@@ -22,6 +31,8 @@ fun InputTextField(
     isPassword: Boolean = false,
     onValueChange: (String) -> Unit
 ) {
+    var passwordVisible by remember { mutableStateOf(false) }
+
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
@@ -47,6 +58,17 @@ fun InputTextField(
             focusedBorderColor = Lemon,
             unfocusedBorderColor = Lemon,
         ),
-        visualTransformation = if (isPassword) PasswordVisualTransformation() else VisualTransformation.None
+        visualTransformation = if (isPassword && !passwordVisible) PasswordVisualTransformation() else VisualTransformation.None,
+        trailingIcon = {
+            if (isPassword) {
+                IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                    Icon(
+                        imageVector = if (passwordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+                        contentDescription = if (passwordVisible) "비밀번호 숨기기" else "비밀번호 보기",
+                        tint = Lemon
+                    )
+                }
+            }
+        }
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ roomRuntime = "2.7.1"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }
 androidx-room-guava = { module = "androidx.room:room-guava", version.ref = "roomRuntime" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }


### PR DESCRIPTION
### 변경 사항
- `proguard-rules.pro` 파일 생성 및 내용 업데이트  
  - Glide, Retrofit, Gson 등 주요 라이브러리 난독화 제외 처리  
  - 사용되지 않는 코드/리소스 제거 설정 추가  
- `build.gradle` (모듈) 릴리즈 빌드에 ProGuard 룰 적용  
- **로그인 화면 UI 개선**  
  - 비밀번호 입력 필드에 입력 내용 표시/숨김 토글(눈 아이콘) 추가  
  - 토글 클릭 시 비밀번호 가시성 전환 로직 구현  

### 목적
- APK/AAB 패키지 용량 절감 및 런타임 성능 최적화  
- 코드 난독화를 통한 보안 강화  
- 사용자 편의성 향상: 비밀번호 입력 시 가시성 토글 제공  

### 테스트 시나리오
1. 릴리즈 빌드(AAB) 정상 생성 확인  
2. APK 설치 후 주요 기능(로그인, 이미지 로딩, 네트워크 통신) 동작 검증  
3. Android Lint 및 ProGuard 경고/오류 없는지 확인  
4. 로그인 화면 진입 → 비밀번호 입력 → 눈 아이콘 클릭 시 입력값이 보이고/숨겨지는지 확인  

### 참고
- ProGuard 룰은 필요에 따라 추후 조정될 수 있습니다.  
- 혹시 누락된 예외 처리 대상 라이브러리가 있으면 코멘트 부탁드립니다.  
